### PR TITLE
adds elm-version to elm-package.json file

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,5 +10,6 @@
     "dependencies": {
         "elm-lang/core": "1.1.0 <= v < 2.0.0",
         "evancz/elm-html": "2.0.0 <= v < 3.0.0"
-    }
+    },
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }


### PR DESCRIPTION
Currently `elm-package install` throws an error due to a missing `elm-version` property in the `elm-package.json` file

![Image install-error](https://dl.dropboxusercontent.com/u/13155426/Screen%20Shot%202016-03-05%20at%202.44.45%20PM.png)
